### PR TITLE
Provide docs on Helm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@
 
 [Self-hosted gateway](https://aka.ms/apim/sputnik/overview) is a feature of [Azure API Management](https://aka.ms/apimrocks). The self-hosted gateway, a containerized version of the API Management gateway component, expands API Management support for hybrid and multi-cloud environments. It allows customers to manage all of their APIs using a single API management solution without compromising security, compliance, or performance. Customers can deploy the self-hosted gateways to the same environments where they host their APIs while continuing to manage them from an associated API Management service in Azure.
 
+## Installing with Helm
+
+The Azure API Management Self-Hosted Gateway is available as a Helm chart and can be easily installed on Kubernetes.
+
+Install the Helm repo:
+```cli
+helm repo add azure-apim-gateway https://azure.github.io/api-management-self-hosted-gateway/helm-charts/
+```
+
+Update repo to fetch the latest Helm charts:
+```cli
+helm repo update
+```
+
+To install the chart with the release name `azure-api-management-gateway`:
+```
+helm install --name azure-api-management-gateway azure-apim-gateway/azure-api-management-gateway \
+             --set gateway.endpoint='<azure-api-management-url>' \
+             --set gateway.authKey='<azure-api-management-gateway-key>'
+```
+
+This will deploy the Azure API Management Self-Hosted gateway on your Kubernetes cluster, but we provide options to configure it according to your needs.
+
+To learn more, we recommend inspecting the Helm chart:
+```cli
+helm inspect all azure-apim-gateway/azure-api-management-gateway
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/helm-charts/azure-api-management-gateway/README.md
+++ b/helm-charts/azure-api-management-gateway/README.md
@@ -6,8 +6,8 @@
 We are using Helm v3.
 
 ```console
-helm repo add apim-gateway https://azure.github.io/api-management-self-hosted-gateway/helm-charts/
-helm install azure-api-management-gateway apim-gateway/azure-api-management-gateway
+helm repo add azure-apim-gateway https://azure.github.io/api-management-self-hosted-gateway/helm-charts/
+helm install azure-api-management-gateway azure-apim-gateway/azure-api-management-gateway
 ```
 
 ## Introduction
@@ -27,7 +27,7 @@ This chart bootstraps an **Azure API Management gateway** deployment on a Kubern
 To add the chart repository:
 
 ```console
-helm repo add apim-gateway https://azure.github.io/api-management-self-hosted-gateway/helm-charts/
+helm repo add azure-apim-gateway https://azure.github.io/api-management-self-hosted-gateway/helm-charts/
 ```
 
 ## Install the Chart
@@ -35,7 +35,7 @@ helm repo add apim-gateway https://azure.github.io/api-management-self-hosted-ga
 To install the chart with the release name `azure-api-management-gateway`:
 
 ```console
-helm install --name azure-api-management-gateway apim-gateway/azure-api-management-gateway \
+helm install --name azure-api-management-gateway azure-apim-gateway/azure-api-management-gateway \
              --set gateway.endpoint='<gateway-url>' \
              --set gateway.authKey='<gateway-key>'
 ```
@@ -80,5 +80,5 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 be provided while installing the chart. For example,
 
 ```console
-helm install apim-gateway/azure-api-management-gateway --name azure-api-management-gateway -f values.yaml
+helm install azure-apim-gateway/azure-api-management-gateway --name azure-api-management-gateway -f values.yaml
 ```


### PR DESCRIPTION
Provide docs on Helm installation to make it easier to get people started.

Renamed the sample repo (`apim-gateway`) to `azure-apim-gateway` in case they have other repos configured already to clarify that it's Azures APIM Gateway.