### PR TITLE
Change ingress apiVersion for kubernetes versions 1.14 and higher.

### DIFF
--- a/helm-charts/azure-api-management-gateway/Chart.yaml
+++ b/helm-charts/azure-api-management-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart to deploy an Azure API Management Gateway on Kubernetes
 name: azure-api-management-gateway
-version: 0.1.1
+version: 0.1.0

--- a/helm-charts/azure-api-management-gateway/Chart.yaml
+++ b/helm-charts/azure-api-management-gateway/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart to deploy an Azure API Management Gateway on Kubernetes
 name: azure-api-management-gateway
-version: 0.1.0
+version: 0.1.1

--- a/helm-charts/azure-api-management-gateway/templates/ingress.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/ingress.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "azure-api-management-gateway.fullname" . -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
The extensions/v1beta1 api for ingress is being removed in 1.16
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

The new api has been available since kubernetes version 1.14 so we can
simply have a conditional on it.

Signed-off-by: Kristinn Björgvin Árdal <kristinnardalsecondary@gmail.com>