### PR TITLE
Add nodeSelector to test pod

### DIFF
--- a/helm-charts/azure-api-management-gateway/templates/tests/test-connection.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/tests/test-connection.yaml
@@ -16,3 +16,7 @@ spec:
       command: ['wget']
       args:  ['{{ include "azure-api-management-gateway.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}


### PR DESCRIPTION
For clusters with multiple operating systems it is necessary to ensure that all pods contain OS scheduling requirements so that they are scheduled on a compatible node. This is covered in all templates in the chart except for the test pod which this PR adds support for.