### PR TITLE
Provide capability to specify annotations to the service

### DIFF
--- a/helm-charts/azure-api-management-gateway/templates/service.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "azure-api-management-gateway.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -12,10 +12,6 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-service:
-  type: ClusterIP
-  port: 88
-
 gateway:
   endpoint: ""
   authKey: ""
@@ -27,6 +23,11 @@ dapr:
   logging:
     useJsonOutput: true
     level: info
+
+service:
+  type: ClusterIP
+  port: 88
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Closes #22

### Without annotations

```
❯ helm template .\helm-charts\azure-api-management-gateway\
<redacted>
---
# Source: azure-api-management-gateway/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-azure-api-management-gateway
  labels:
    app.kubernetes.io/name: azure-api-management-gateway
    helm.sh/chart: azure-api-management-gateway-0.3.0
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
```

### With annotations

```diff
❯ helm template .\helm-charts\azure-api-management-gateway\ --values .\lint-values.yml
<redacted>
---
# Source: azure-api-management-gateway/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-azure-api-management-gateway
  labels:
    app.kubernetes.io/name: azure-api-management-gateway
    helm.sh/chart: azure-api-management-gateway-0.3.0
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
+ annotations:
+   service.beta.kubernetes.io/azure-dns-label-name: example-annotation
spec:
  type: ClusterIP
  ports:
```