### PR TITLE
Enforce users to specify gateway configuration

### DIFF
--- a/.github/workflows/lint-helm-charts.yml
+++ b/.github/workflows/lint-helm-charts.yml
@@ -12,4 +12,9 @@ jobs:
       uses: Azure/setup-helm@v1
 
     - name: Lint 'azure-api-management-gateway' Helm chart
-      run: helm lint helm-charts/azure-api-management-gateway
+      # We are using dummy gateway parameters here just to show how you can pass them as they are required
+      run: helm lint helm-charts/azure-api-management-gateway --set gateway.endpoint=abc --set gateway.authKey=XYZ
+
+    - name: Template 'azure-api-management-gateway' Helm chart
+      # We are using dummy gateway parameters here just to show how you can pass them as they are required
+      run: helm template helm-charts/azure-api-management-gateway --set gateway.endpoint=abc --set gateway.authKey=XYZ

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -17,8 +17,8 @@ service:
   port: 88
 
 gateway:
-  endpoint: ""
-  authKey: ""
+  endpoint: 
+  authKey: 
 
 dapr:
   enabled: false


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

### Example without specifying configuration (bad)

```shell
❯ helm lint .\helm-charts\azure-api-management-gateway\
==> Linting .\helm-charts\azure-api-management-gateway\
[ERROR] templates/: template: azure-api-management-gateway/templates/secret.yaml:12:44: executing "azure-api-management-gateway/templates/secret.yaml" at <b64enc>: invalid value; expected string

Error: 1 chart(s) linted, 1 chart(s) failed
```

### Example wit specifying configuration (good)

```shell
❯ helm lint .\helm-charts\azure-api-management-gateway\ --set gateway.endpoint=abc --set gateway.authKey=XYZ
==> Linting .\helm-charts\azure-api-management-gateway\

1 chart(s) linted, 0 chart(s) failed
```