### PR TITLE
Use app version as image tag & update Helm chart spec

### DIFF
--- a/helm-charts/azure-api-management-gateway/Chart.yaml
+++ b/helm-charts/azure-api-management-gateway/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
-appVersion: "0.1"
-description: A Helm chart to deploy an Azure API Management Gateway on Kubernetes
+version: 0.3.0
+appVersion: 1.1.2
 name: azure-api-management-gateway
-version: 0.2.0
+description: A Helm chart to deploy an Azure API Management Gateway on Kubernetes
+home: https://azure.microsoft.com/en-us/services/api-management/
+sources:
+  - https://github.com/Azure/api-management-self-hosted-gateway
+maintainers:
+  - name: Vlad Vinogradsky
+    url: https://github.com/vladvino
+  - name: Miao Jiang
+    url: https://github.com/miaojiang
+  - name: Tom Kerkhove
+    url: https://github.com/tomkerkhove
+icon: https://github.com/Azure/API-Management/raw/main/media/apim-logo.png

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 
 image:
   repository: mcr.microsoft.com/azure-api-management/gateway
-  tag: latest
   pullPolicy: IfNotPresent
+  tag: 
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Use app version as image tag & update Helm chart spec.

### Updated Helm chart spec

This allows us to have a more discoverable Helm chart on Artifact Hub.

### Changes to image tagging

**🔔 This will change the way the gateway is released**

Every new version of the gateway container, should bump the app version. This allows operators to understand what image is running in the cluster instead of always using `latest` which is an anti-pattern ([learn more](https://codefresh.io/kubernetes-tutorial/kubernetes-antipatterns-1/).