### PR TITLE
test: Automatically run deploy against multiple Kubernetes versions

### DIFF
--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        node_image: kindest/node:${{ matrix.kubernetesVersion }}
+        node_image: ${{ matrix.image }}
 
     - name: Show Kubernetes version
       run: |

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -17,6 +17,7 @@ jobs:
 
   deploy-helm-3-x:
     runs-on: ubuntu-latest
+    needs: lint-helm-3-x
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -53,6 +53,10 @@ jobs:
       run: |
         kubectl version
 
+    - name: Show Kubernetes nodes
+      run: |
+        kubectl get nodes -o wide
+
     - name: Show Helm version
       run: |
         helm version

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -70,3 +70,4 @@ jobs:
 
     - name: Show Kubernetes resources
       run: kubectl get all --namespace apim-gateway
+      if: always()

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -1,4 +1,4 @@
-name: Lint Helm Chart
+name: Helm Chart CI
 on: [pull_request]
 
 jobs:
@@ -17,6 +17,25 @@ jobs:
 
   deploy-helm-3-x:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Images are defined on every Kind release
+          # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.22
+          image: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+        - kubernetesVersion: v1.21
+          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - kubernetesVersion: v1.20
+          image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+        - kubernetesVersion: v1.19
+          image: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+        - kubernetesVersion: v1.18
+          image: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+        - kubernetesVersion: v1.17
+          image: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
+    name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }}
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -24,8 +43,10 @@ jobs:
     - name: Helm install
       uses: Azure/setup-helm@v1
       
-    - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.0.0
+    - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
+      uses: helm/kind-action@v1.2.0
+      with:
+        node_image: kindest/node:${{ matrix.kubernetesVersion }}
 
     - name: Show Kubernetes version
       run: |

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -25,17 +25,17 @@ jobs:
           # Images are defined on every Kind release
           # See https://github.com/kubernetes-sigs/kind/releases
         - kubernetesVersion: v1.22
-          image: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
         - kubernetesVersion: v1.21
-          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
         - kubernetesVersion: v1.20
-          image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
         - kubernetesVersion: v1.19
-          image: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
         - kubernetesVersion: v1.18
-          image: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
         - kubernetesVersion: v1.17
-          image: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
+          kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }}
     steps:
     - name: Check out code
@@ -47,7 +47,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        node_image: ${{ matrix.image }}
+        node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version
       run: |


### PR DESCRIPTION
We will now automatically deploy the Helm chart on the last 6 Kubernetes versions (v1.22 -> v1.17).