### PR TITLE
chore: Make configuration more future-proof

### DIFF
--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Lint 'azure-api-management-gateway' Helm chart
       # We are using dummy gateway parameters here just to show how you can pass them as they are required
-      run: helm lint helm-charts/azure-api-management-gateway --set gateway.endpoint=abc --set gateway.authKey=XYZ
+      run: helm lint helm-charts/azure-api-management-gateway --set gateway.configuration.uri=abc --set gateway.auth.key=XYZ
 
   deploy-helm-3-x:
     runs-on: ubuntu-latest
@@ -66,11 +66,11 @@ jobs:
 
     - name: Template Helm chart
       # We are using dummy gateway parameters here just to show how you can pass them as they are required
-      run: helm template azure-api-management-gateway ./helm-charts/azure-api-management-gateway --namespace apim-gateway --set gateway.endpoint=${{ secrets.GATEWAY_URL }} --set gateway.authKey=${{ secrets.GATEWAY_KEY }}
+      run: helm template azure-api-management-gateway ./helm-charts/azure-api-management-gateway --namespace apim-gateway --set gateway.configuration.uri=${{ secrets.GATEWAY_URL }} --set gateway.auth.key=${{ secrets.GATEWAY_KEY }}
 
     - name: Install Helm chart
       # We are using dummy gateway parameters here just to show how you can pass them as they are required
-      run: helm install azure-api-management-gateway ./helm-charts/azure-api-management-gateway --namespace apim-gateway --set gateway.endpoint=${{ secrets.GATEWAY_URL }} --set gateway.authKey=${{ secrets.GATEWAY_KEY }} --wait
+      run: helm install azure-api-management-gateway ./helm-charts/azure-api-management-gateway --namespace apim-gateway --set gateway.configuration.uri=${{ secrets.GATEWAY_URL }} --set gateway.auth.key=${{ secrets.GATEWAY_KEY }} --wait
 
     - name: Show Kubernetes resources
       run: kubectl get all --namespace apim-gateway

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ helm repo update
 To install the chart with the release name `azure-api-management-gateway`:
 ```
 helm install azure-api-management-gateway  \
-             --set gateway.endpoint='<azure-api-management-url>' \
-             --set gateway.authKey='<azure-api-management-gateway-key>' \
+             --set gateway.configuration.uri='<azure-api-management-url>' \
+             --set gateway.auth.key='<azure-api-management-gateway-key>' \
              azure-apim-gateway/azure-api-management-gateway
 ```
 

--- a/helm-charts/azure-api-management-gateway/README.md
+++ b/helm-charts/azure-api-management-gateway/README.md
@@ -43,8 +43,8 @@ To install the chart with the release name `azure-api-management-gateway`:
 
 ```console
 helm install --name azure-api-management-gateway azure-apim-gateway/azure-api-management-gateway \
-             --set gateway.endpoint='<gateway-url>' \
-             --set gateway.authKey='<gateway-key>'
+             --set gateway.configuration.uri='<gateway-url>' \
+             --set gateway.auth.key='<gateway-key>'
 ```
 
 The command deploys the [Azure API Management gateway](https://docs.microsoft.com/en-us/azure/api-management/self-hosted-gateway-overview) on the Kubernetes cluster.
@@ -71,14 +71,14 @@ their default values.
 | `image.tag`  | Tag of image to use | `beta`            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `resources`  | Pod resource requests & limits |    `{}`    |
-| `gateway.endpoint`  | Endpoint in Azure API Management to which every self-hosted agent has to connect | ``            |
-| `gateway.authKey`  | Authentication key to authenticate with to Azure API Management service. Typically starts with `GatewayKey ` | ``            |
+| `gateway.configuration.uri`  | Endpoint in Azure API Management to which every self-hosted agent has to connect | `` |
+| `gateway.auth.key`  | Authentication key to authenticate with to Azure API Management service. Typically starts with `GatewayKey ` | ``            |
 | `service.type`  | Type of Kubernetes service to use to expose to serve traffic | `ClusterIP`            |
 | `service.annotations`  | Annotations to add to the Kubernetes service | None            |
 | `service.ports.http`  | Port for HTTP traffic on service for other pods to talk to | `8080`            |
 | `service.ports.https`  | Port for HTTPs traffic on service for other pods to talk to | `8081`            |
 | `dapr.enabled`  | Indication wheter or not Dapr integration should be used | `false`            |
-| `dapr.appId`  | Application ID to use for Dapr integration | None            |
+| `dapr.app.id`  | Application ID to use for Dapr integration | None            |
 | `dapr.config`  | Defines which Configuration CRD Dapr should use | `tracing`            |
 | `dapr.logging.level`  | Level of log verbosity of Dapr sidecar | `info`            |
 | `dapr.logging.useJsonOutput`  | Indication wheter or not logging should be in JSON format | `true`            |

--- a/helm-charts/azure-api-management-gateway/templates/configmap.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/configmap.yaml
@@ -8,4 +8,4 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  config.service.endpoint: {{ .Values.gateway.endpoint | quote }}
+  config.service.endpoint: {{ .Values.gateway.configuration.uri | quote }}

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
       {{ if .Values.dapr.enabled -}}
       annotations:
         dapr.io/enabled: "true"
-        {{ if .Values.dapr.appId -}}
-        dapr.io/app-id: {{ .Values.dapr.appId | quote }}
+        {{ if .Values.dapr.app.id -}}
+        dapr.io/app-id: {{ .Values.dapr.app.id | quote }}
         {{ end }}
         dapr.io/config: {{ .Values.dapr.config | quote }}
         dapr.io/log-as-json: {{ .Values.dapr.logging.useJsonOutput | quote }}

--- a/helm-charts/azure-api-management-gateway/templates/secret.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/secret.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  gateway-key: {{ .Values.gateway.authKey | b64enc | quote }}
+  gateway-key: {{ .Values.gateway.auth.key | b64enc | quote }}

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -14,12 +14,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 gateway:
-  endpoint: 
-  authKey: 
+  configuration:
+    uri: 
+  auth:
+    key: 
 
 dapr:
   enabled: false
-  appId:
+  app:
+    id:
   config: tracing
   logging:
     useJsonOutput: true


### PR DESCRIPTION
As we are going to ship a new major version due to #46, it's the perfect timing to revise our current Helm configuration setup and make it more future-proof.

Breaking changes:
- `gateway.endpoint` ➡️ `gateway.configuration.uri` 
- `gateway.authKey` ➡️ `gateway.auth.key` 
- `dapr.appId` ➡️ `dapr.app.id` 
