### PR TITLE
feat: Allow support for deploying on Kubernetes clusters running pre-release versions

### DIFF
--- a/helm-charts/azure-api-management-gateway/Chart.yaml
+++ b/helm-charts/azure-api-management-gateway/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 version: 1.0.0-rc
 appVersion: 1.2.5
+# Specify the Kubernetes version range that we support.
+# We allow pre-release versions for cloud-specific Kubernetes versions such as  v1.21.5-gke.1302 or v1.18.9-eks-d1db3c
 kubeVersion: ">=v1.17.0-0"
 name: azure-api-management-gateway
 description: A Helm chart to deploy the self-hosted gateway of Azure API Management on Kubernetes

--- a/helm-charts/azure-api-management-gateway/Chart.yaml
+++ b/helm-charts/azure-api-management-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 version: 1.0.0-rc
 appVersion: 1.2.5
-kubeVersion: ">=v1.17.0"
+kubeVersion: ">=v1.17.0-0"
 name: azure-api-management-gateway
 description: A Helm chart to deploy the self-hosted gateway of Azure API Management on Kubernetes
 home: https://azure.microsoft.com/en-us/services/api-management/


### PR DESCRIPTION
I would like the APIM chart to support pre-release/non-vanilla versions of Kubernetes, for instance v1.21.5-gke.1302 or v1.18.9-eks-d1db3c. This fix should add support for these Kubernetes versions.