### PR TITLE
fix: Use Kind v1.3.0 for Kubernetes v1.24 validation

### DIFF
--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.13.0
+        version: v0.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
+        version: 1.3.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-helm-chart.yml
+++ b/.github/workflows/ci-helm-chart.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.3.0
+        version: 1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version


### PR DESCRIPTION
Use Kind v1.3.0 for Kubernetes v1.24 validation to coop with breaking changes.

> You must use kind v0.13.0+ with Kubernetes v1.24.0+ images, and if you built your own Kubernetes v1.24.0+ image with a previous kind version you will need to re-built when switching to kind v0.13.0+.

https://github.com/kubernetes-sigs/kind/releases/tag/v0.13.0