### PR TITLE
feat: Use 3 replicas of gateway by default for HA purposes

### DIFF
--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
 
 image:
   repository: mcr.microsoft.com/azure-api-management/gateway


### PR DESCRIPTION
Use 3 replicas of gateway by default for HA purposes to ensure that there is no single-point-of-failure