### PR TITLE
feat: Provide support for configuring hostAliases

### DIFF
--- a/helm-charts/azure-api-management-gateway/README.md
+++ b/helm-charts/azure-api-management-gateway/README.md
@@ -86,6 +86,7 @@ their default values.
 | `gateway.configuration.backup.persistentVolumeClaim.size` | Size of the Persistent Volume Claim (PVC) to be created | `50Mi` |
 | `gateway.configuration.additional` | Capability to specify a list of settings to add which are not supported by the Helm chart yet. | `{}` |
 | `gateway.auth.key` | Authentication key to authenticate with to Azure API Management service. Typically starts with `GatewayKey` | |
+| `gateway.deployment.dns.hostAliases` | Add custom host aliases (configuration endpoint e.g.) Check the [values.yaml](./values.yaml) for the details. |  `{}` |
 | `secret.createSecret` | Indication whether or not a Kubernetes secret should be created to store the authentication token. | `true` |
 | `secret.existingSecretName` | Name of the existing secret to be used by the gateway. Requires `secret.createSecret` to be false. | |
 | `observability.azureMonitor.metrics.enabled` | Indication whether or not metrics should be sent to Azure Monitor. Learn more in [our documentation](https://docs.microsoft.com/en-us/azure/api-management/how-to-configure-cloud-metrics-logs#metrics). | `true` |

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         dapr.io/log-level: {{ .Values.dapr.logging.level | quote }}
       {{- end }}
     spec:
-      {{- with .Values.gateway.deployment.hostAliases }}
+      {{- with .Values.gateway.deployment.dns.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}       

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         dapr.io/log-level: {{ .Values.dapr.logging.level | quote }}
       {{- end }}
     spec:
+      {{- with .Values.gateway.deployment.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}       
       {{- if .Values.gateway.deployment.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.gateway.deployment.terminationGracePeriodSeconds }}
       {{- end }}

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -22,10 +22,11 @@ gateway:
       # rollingUpdate:
       #   maxUnavailable: 0
       #   maxSurge: 25%
-    hostAliases: {}
-      # - ip: "<ip address>"
-      #   hostnames:
-      #   - "<instanceName>.configuration.azure-api.net"      
+    dns:
+      hostAliases: {}
+        # - ip: "<ip address>"
+        #   hostnames:
+        #   - "<instanceName>.configuration.azure-api.net"      
   configuration:
     uri: 
     backup:

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -22,6 +22,10 @@ gateway:
       # rollingUpdate:
       #   maxUnavailable: 0
       #   maxSurge: 25%
+    hostAliases: {}
+      # - ip: "<ip address>"
+      #   hostnames:
+      #   - "<instanceName>.configuration.azure-api.net"      
   configuration:
     uri: 
     backup:


### PR DESCRIPTION
The configuration URL is not added to the public DNS in case the APIM is in VNET. 
This way you can specify given configuration URL and it's IP directly to the APIM deployment.