### PR TITLE
feat: add option to set custom annotation for deployment

### DIFF
--- a/helm-charts/azure-api-management-gateway/README.md
+++ b/helm-charts/azure-api-management-gateway/README.md
@@ -77,6 +77,7 @@ their default values.
 | `image.pullPolicy` | Policy to pull image | `IfNotPresent` |
 | `gateway.deployment.terminationGracePeriodSeconds` | Determines the maximum time the Pod may spend in the Terminating phase. Learn more [about the termination of Pods](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) | `60` |
 | `gateway.deployment.strategy` | Specifies the deployment [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) to use for replacing old pods by new ones. May be `Recreate` or `RollingUpdate` | `{}` |
+| `gateway.deployment.annotations` | Specify additonal custom annotations to be set for the deployment manifest | |
 | `gateway.configuration.uri` | Endpoint in Azure API Management to which every self-hosted agent has to connect | |
 | `gateway.configuration.backup.enabled` | If enabled will store a backup copy of the latests downloaded configuration on a storage volume | `false` |
 | `gateway.configuration.backup.persistentVolumeClaim.existingName` | Use an existing Persistent Volume Claim (PVC) instead of creating one. *.persistentVolumeClaim.create needs to be false | `""` |

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         dapr.io/enabled: "true"
         {{ if .Values.dapr.app.id -}}
         dapr.io/app-id: {{ .Values.dapr.app.id | quote }}
-        {{ end -}}
+        {{- end }}
         dapr.io/config: {{ .Values.dapr.config | quote }}
         dapr.io/log-as-json: {{ .Values.dapr.logging.useJsonOutput | quote }}
         dapr.io/log-level: {{ .Values.dapr.logging.level | quote }}

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -17,15 +17,20 @@ spec:
     metadata:
       labels:
         {{- include "azure-api-management-gateway.selectorLabels" . | nindent 8 }}
-      {{- if .Values.dapr.enabled -}}
+      {{- if or .Values.dapr.enabled .Values.gateway.deployment.annotations }}
       annotations:
+        {{- if .Values.gateway.deployment.annotations -}}
+          {{- toYaml .Values.gateway.deployment.annotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.dapr.enabled }}
         dapr.io/enabled: "true"
         {{ if .Values.dapr.app.id -}}
         dapr.io/app-id: {{ .Values.dapr.app.id | quote }}
-        {{ end }}
+        {{ end -}}
         dapr.io/config: {{ .Values.dapr.config | quote }}
         dapr.io/log-as-json: {{ .Values.dapr.logging.useJsonOutput | quote }}
         dapr.io/log-level: {{ .Values.dapr.logging.level | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if .Values.gateway.deployment.terminationGracePeriodSeconds }}

--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -22,6 +22,8 @@ gateway:
       # rollingUpdate:
       #   maxUnavailable: 0
       #   maxSurge: 25%
+    #annotations:
+    #  com.example/local: "test"
   configuration:
     uri: 
     backup:


### PR DESCRIPTION
Added an option to define custom annotation for the gateway deployment.

While testing I found out that the current implementation for dapr handling is broken. Following error occurs:
```
Helm upgrade failed: YAML parse error on azure-api-management-gateway/templates/deployment.yaml: error converting YAML to JSON: yaml: line 24: mapping ││  values are not allowed in this context
```

This bug is also fixed with this PR.
