### PR TITLE
fix: Changed deployment.yaml to use if instead of with statement

### DIFF
--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -125,9 +125,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+{{- if .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.affinity | nindent 8 }}
 {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -145,7 +145,7 @@ spec:
                   - {{ .Release.Name }}
               topologyKey: topology.kubernetes.io/zone
 {{- end -}}
-    {{- end }}
+{{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The current configuration that uses ```{{- with .Values.affinity }}``` results in Helm failing to generate the template when ```.Values.affinity``` is set.

This is caused because with sets the context to ```.Values.affinity```, which makes the values of ```.Capablilities``` and ```.Release``` nil, resulting in the following error:

```
Error: template: azure-api-management-gateway/templates/deployment.yaml:131:44: executing "azure-api-management-gateway/templates/deployment.yaml" at <.Capabilities.KubeVersion.Version>: nil pointer evaluating interface {}.KubeVersion
```

Changing the ```with``` to an ```if``` statement and expanding ```toYaml .``` into ```toYaml .Values.affinity``` fixes this error.