### PR TITLE
chore: Remove legacy Kubernetes features

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -79,13 +79,14 @@ body:
     label: Kubernetes Version
     description: What version of Kubernetes that are you running?
     options:
+    - "1.26"
+    - "1.25"
+    - "1.24"
+    - "1.23"
     - "1.22"
     - "1.21"
     - "1.20"
-    - "1.19"
-    - "1.18"
-    - "1.17"
-    - "< 1.17"
+    - "<1.20"
     - "Other"
   validations:
     required: false

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -111,7 +111,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- if .Values.highAvailability.enabled }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version }}
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
@@ -120,32 +119,14 @@ spec:
           matchLabels:
             {{- include "azure-api-management-gateway.selectorLabels" . | nindent 12 }}
 {{- end }}
-{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- if .Values.affinity }}
+    {{- with .Values.affinity }}
       affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
-{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - {{ include "azure-api-management-gateway.name" . }}
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                  - {{ .Release.Name }}
-              topologyKey: topology.kubernetes.io/zone
-{{- end -}}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/test-config.yml
+++ b/test-config.yml
@@ -5,3 +5,14 @@ ingress:
       paths: [
         "/api/v1/products"
       ]
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - somenode1.test.com
+          - somenode2.test.com
+          - somenode3.test.com


### PR DESCRIPTION
Remove legacy Kubernetes features as we don't allow these Kubernetes versions anymore and follow-up on #188 as the main problem was the version check.

Also added affinity to the test configuration.