### PR TITLE
fix: 0 replica count should not be reduced

### DIFF
--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "azure-api-management-gateway.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.replicaCount }}
+  {{- if not (quote .Values.replicaCount | empty) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:


### PR DESCRIPTION
Minor bug in my [previous commit](https://github.com/Azure/api-management-self-hosted-gateway/pull/263) where the `replicaCount: 0` was considered as an `null` and was reduced.

The correct behavior should be:

replicaCount: 1 -> replicas: 1
replicaCount: 0 -> replicas: 0
replicaCount:  -> reduced
replicaCount: NULL -> reduced

