### PR TITLE
feat: add option to set priority class

### DIFF
--- a/helm-charts/azure-api-management-gateway/README.md
+++ b/helm-charts/azure-api-management-gateway/README.md
@@ -153,6 +153,7 @@ their default values.
 | `probes.startup` | Configuration for startup probes of the container | Uses `/status-0123456789abcdef` as endpoint for HTTP probes |
 | `securityContext` | Privilege and access control settings for the  container | `{}` |
 | `podSecurityContext` | Privilege and access control settings for the  pod | `{}` |
+| `priorityClassName` | Priority class name for the pod e.g. `priority` | |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/helm-charts/azure-api-management-gateway/templates/deployment.yaml
+++ b/helm-charts/azure-api-management-gateway/templates/deployment.yaml
@@ -150,6 +150,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
 {{- if .Values.highAvailability.enabled }}
       topologySpreadConstraints:
       - maxSkew: 1


### PR DESCRIPTION
add option to run gateway with a custom priorityClass to make it easier to run the gateway with higher priority than other pods in the cluster. See [kubernetes docs](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for more details.
