### PR TITLE
feat: Adding failureThreshold to startupProbe

### DIFF
--- a/helm-charts/azure-api-management-gateway/values.yaml
+++ b/helm-charts/azure-api-management-gateway/values.yaml
@@ -156,6 +156,7 @@ probes:
     httpGet:
       path: /status-0123456789abcdef
       port: http
+    failureThreshold: 10
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Adding failureThreshold in startupProbe to 10. Default value ( 3 ) is too small causing infinit restarting of pods. 

