### PR TITLE
feat: Add Copilot instructions and new-release skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,81 @@
+# Copilot Instructions
+
+## Repository Overview
+
+This repository maintains the **Helm chart** for the Azure API Management Self-Hosted Gateway and serves as the release announcement channel. It does not contain the gateway source code—only the Helm chart, packaged chart archives, CI workflows, and documentation.
+
+The single Helm chart lives in `helm-charts/azure-api-management-gateway/`. Packaged `.tgz` releases and `index.yaml` sit alongside it in `helm-charts/`.
+
+## Build, Lint, and Test
+
+```bash
+# Lint the chart (gateway token auth)
+helm lint helm-charts/azure-api-management-gateway \
+  --set gateway.configuration.uri="example.configuration.azure-api.net" \
+  --set gateway.auth.key="GatewayKey xyz"
+
+# Lint the chart (Azure AD auth)
+helm lint helm-charts/azure-api-management-gateway \
+  --set gateway.configuration.uri="example.configuration.azure-api.net" \
+  --set gateway.auth.type="AzureAdApp" \
+  --set gateway.name=gw \
+  --set gateway.auth.azureAd.tenant.id=tid \
+  --set gateway.auth.azureAd.app.id=aid \
+  --set gateway.auth.azureAd.app.secret=xyz
+
+# Dry-run template rendering
+helm install test ./helm-charts/azure-api-management-gateway \
+  --set gateway.configuration.uri="example.configuration.azure-api.net" \
+  --set gateway.auth.key="GatewayKey xyz" \
+  --dry-run
+
+# Regenerate chart README from template
+# Requires helm-docs v1.14.2 (https://github.com/norwoodj/helm-docs)
+cd helm-charts/azure-api-management-gateway && helm-docs
+
+# Run pre-commit hooks (includes helm-docs)
+pre-commit run --all-files
+```
+
+CI (`ci-pr.yml`) runs three checks on PRs: `validate-helm-docs`, `lint-helm`, and `deploy-helm` (Kind cluster matrix across K8s versions × HA on/off).
+
+## Key Conventions
+
+### Helm Chart Documentation
+
+`README.md` in the chart directory is **auto-generated** by [helm-docs](https://github.com/norwoodj/helm-docs) from `README.md.gotmpl` and `values.yaml` comments. Never edit `README.md` directly—edit the `.gotmpl` template or `values.yaml` `# --` comments instead. CI will fail if the generated README is stale.
+
+### Values Documentation Format
+
+Document values with `# --` comment lines immediately above the value in `values.yaml`. This is the helm-docs convention that drives README generation:
+
+```yaml
+# -- Description of the parameter.
+parameterName: defaultValue
+```
+
+### PR Title Convention
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) (enforced by the Semantic PRs GitHub app, title-only mode).
+
+### Helm Chart Release Process
+
+The full release process is documented in [CONTRIBUTING.md](../CONTRIBUTING.md#release-process). Invoke the `new-release` skill (`.github/skills/new-release/SKILL.md`) to walk through all release steps including Chart.yaml updates, helm-docs regeneration, chart packaging, repo indexing, PR creation, and draft GitHub release preparation.
+
+### Authentication Modes
+
+The chart supports three authentication types (`gateway.auth.type`):
+- **GatewayToken** (default) — uses `gateway.auth.key`
+- **AzureAdApp** — uses client secret/certificate via Azure AD
+- **WorkloadIdentity** — uses managed identity via Workload Identity Federation
+
+Template logic in `deployment.yaml` branches on `$authenticationType` to set environment variables and secret references accordingly.
+
+### Pre-commit Hooks
+
+A `.pre-commit-config.yaml` is configured with `helm-docs-container`. Install with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/.github/skills/new-release/SKILL.md
+++ b/.github/skills/new-release/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: new-release
+description: >-
+  Skill for releasing a new Helm chart version for the Azure API Management Self-Hosted Gateway,
+  optionally with a new container image version. Handles Chart.yaml updates, helm-docs regeneration,
+  chart packaging, repo indexing, PR creation, and draft GitHub release preparation.
+user-invocable: true
+---
+
+# Releasing a New Helm Chart Version
+
+This skill guides you through the full release process for the Azure API Management Self-Hosted Gateway Helm chart.
+
+## Prerequisites
+
+Before starting, confirm the user provides:
+
+1. **Helm chart version** (required) — the new semver version (e.g. `1.16.0`)
+2. **Container image version** (optional) — if a new container image is being released (e.g. `2.12.0`)
+
+## Release Process
+
+Follow the release process documented in [`CONTRIBUTING.md` § Release Process](../../CONTRIBUTING.md#release-process).
+
+Key points:
+
+- Read `helm-charts/azure-api-management-gateway/Chart.yaml` to get the current `version` and `appVersion`
+- Validate that the new Helm chart version is greater than the current version
+- Create a `release/<helmChartVersion>` branch from `main`
+- Use `--no-verify` when committing (the pre-commit hook requires Docker for helm-docs-container, but we run helm-docs natively)
+- PR title must follow Conventional Commits: `chore: Release Helm chart version <helmChartVersion>`
+- `helm repo index` rewrites timestamps across ALL entries in `index.yaml`, creating a large diff — this is expected
+
+## Draft GitHub Releases
+
+After completing the Helm chart PR, prepare draft GitHub releases.
+
+### Container Release (only if new container image version)
+
+This draft release can be created **before** the Helm chart PR is merged.
+
+- **Tag:** `Container-v<containerImageVersion>`
+- **Title:** `Container v<containerImageVersion>`
+- **Target:** `main`
+- **Draft:** Yes
+- **Body:** Use the template in [`templates/container-release.md`](templates/container-release.md), replacing `<containerImageVersion>` with the actual version
+
+### Helm Chart Release
+
+This draft release should be created **after** the Helm chart PR is merged.
+
+- **Tag:** `v<helmChartVersion>`
+- **Title:** `Helm chart v<helmChartVersion>`
+- **Target:** `main`
+- **Draft:** Yes
+- **Body:** Use the template in [`templates/helm-release.md`](templates/helm-release.md), replacing placeholders:
+  - `<helmChartVersion>` — new Helm chart version
+  - `<containerImageVersion>` — container image version (new or current)
+  - `<previousHelmChartVersion>` — previous Helm chart version (for the changelog link)
+- If no new container image was released, replace the container feature line with: `- Uses container image v<containerImageVersion> (unchanged)`
+
+## Summary Checklist
+
+Present this checklist to the user after completing all steps:
+
+- [ ] Chart.yaml updated (version + appVersion)
+- [ ] README.md regenerated via helm-docs
+- [ ] Helm lint passed
+- [ ] Chart packaged (.tgz created)
+- [ ] Repo index updated (index.yaml)
+- [ ] Branch pushed and PR created
+- [ ] Container draft release created (if applicable)
+- [ ] Helm chart draft release created (after PR merge)

--- a/.github/skills/new-release/templates/container-release.md
+++ b/.github/skills/new-release/templates/container-release.md
@@ -1,0 +1,45 @@
+## Getting started
+
+You can easily install the self-hosted gateway with Docker:
+
+```
+docker run -d -p 8080:8080 -p 8081:8081 --name <gateway-name> \
+  --env config.service.endpoint=<instance-name>.configuration.azure-api.net \
+  config.service.auth=<auth-token> \
+  mcr.microsoft.com/azure-api-management/gateway:<containerImageVersion>
+```
+
+Learn how you can install it on other container platforms:
+
+- [Deploy self-hosted gateway on Kubernetes with Helm](https://aka.ms/apim/sputnik/deploy/k8s/helm)
+- [Deploy self-hosted gateway on Kubernetes with Azure Arc (Preview)](https://aka.ms/apim/sputnik/deploy/k8s/arc)
+- [Deploy self-hosted gateway on Kubernetes with YAML](https://aka.ms/apim/sputnik/deploy/k8s/yaml)
+
+Here are other relevant resources:
+
+- [Authenticate self-hosted gateway with Azure AD](https://learn.microsoft.com/en-us/azure/api-management/self-hosted-gateway-enable-azure-ad)
+- [Self-hosted gateway on Microsoft Artifact Registry](https://aka.ms/apim/shgw/registry-portal)
+- [Our image tagging strategy](https://aka.ms/apim/shgw/image-tagging)
+
+## What is new?
+
+### Highlights
+
+- TBD
+
+### Features
+
+- TBD
+- Keep an eye on [official repo](https://github.com/Azure/API-Management/releases) for more soon
+
+### Fixes / Changes
+
+- TBD
+
+### Breaking Changes
+
+None.
+
+### Removal
+
+None.

--- a/.github/skills/new-release/templates/helm-release.md
+++ b/.github/skills/new-release/templates/helm-release.md
@@ -1,0 +1,24 @@
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/azure-api-management)](https://artifacthub.io/packages/helm/azure-api-management/azure-api-management-gateway/<helmChartVersion>)
+
+_Chart: v<helmChartVersion> | App: v<containerImageVersion>_
+
+## What is new?
+
+### Features
+
+- Use container image v<containerImageVersion> ([release notes](https://github.com/Azure/api-management-self-hosted-gateway/releases/tag/Container-v<containerImageVersion>))
+- TBD
+
+### Fixes / Changes
+
+- TBD
+
+### Breaking Changes
+
+None.
+
+### Removal
+
+None.
+
+**Full Changelog**: https://github.com/Azure/api-management-self-hosted-gateway/compare/v<previousHelmChartVersion>...v<helmChartVersion>


### PR DESCRIPTION
Add .github/copilot-instructions.md with build/lint/test commands, key conventions and release process documentation.

Add .github/skills/new-release/SKILL.md skill that guides the agent through the full Helm chart release process including Chart.yaml updates, helm-docs regeneration, chart packaging, repo indexing, PR creation, and draft GitHub release preparation with templates.