### PR TITLE
chore: Add GitHub MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}


### PR DESCRIPTION
Configure the remote GitHub MCP server with full read/write capabilities via the Copilot API endpoint. This enables tools for creating pull requests, releases, and other write operations through the MCP protocol.